### PR TITLE
Self-filtering option for individual filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,8 +335,14 @@ All depends on your use case of the library.
 Initially, the library was developed to simplify the construction of a search UI.
 If you want to use the library at the level of technical analysis, statistics, etc. , then enabling self-filtering can help you to get expected results.
 
+For all filters:
 ```php
 $query = (new AggregationQuery())->filters($filters)->countItems()->sort()->selfFiltering(true);
+```
+
+For individual filter
+```php
+$filters[] = (new ValueIntersectionFilter('size', [12,32]))->selfFiltering(true);
 ```
 
 

--- a/README.md
+++ b/README.md
@@ -340,7 +340,7 @@ For all filters:
 $query = (new AggregationQuery())->filters($filters)->countItems()->sort()->selfFiltering(true);
 ```
 
-For individual filter
+For individual filter:
 ```php
 $filters[] = (new ValueIntersectionFilter('size', [12,32]))->selfFiltering(true);
 ```

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,16 @@
 # Changelog
 
+### v3.2.1 (xx.11.2023)
+
+Self-filtering option for individual filter (disabled by default). [Feature Request](https://github.com/k-samuel/faceted-search/issues/37)
+Advanced configuration for AggregationQuery, if enabled, then result for filter can contain only filter values.
+Useful for cases with ValueIntersectionFilter  (AND condition).
+```php
+$filters[] = (new ValueIntersectionFilter('size', [12,32]))->selfFiltering(true);
+```
+
+
+
 ### v3.2.0 (29.11.2023)
 
 - ValueIntersectionFilter added [Feature Request](https://github.com/k-samuel/faceted-search/issues/33)

--- a/changelog.md
+++ b/changelog.md
@@ -1,6 +1,6 @@
 # Changelog
 
-### v3.2.1 (xx.11.2023)
+### v3.2.1 (04.12.2023)
 
 Self-filtering option for individual filter (disabled by default). [Feature Request](https://github.com/k-samuel/faceted-search/issues/37)
 Advanced configuration for AggregationQuery, if enabled, then result for filter can contain only filter values.

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "k-samuel/faceted-search",
-    "version": "3.2.0",
+    "version": "3.2.1",
     "type": "library",
     "description": "PHP Faceted search",
     "keywords": ["php","faceted search"],

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -109,7 +109,7 @@ abstract class AbstractFilter implements FilterInterface
      * Get self-filtering flag
      * @return boolean
      */
-    public function getSelfFiltering(): bool
+    public function hasSelfFiltering(): bool
     {
         return $this->selfFiltering;
     }

--- a/src/Filter/AbstractFilter.php
+++ b/src/Filter/AbstractFilter.php
@@ -43,6 +43,12 @@ abstract class AbstractFilter implements FilterInterface
     protected $value;
 
     /**
+     * Self filtering is disabled by default
+     * @var boolean
+     */
+    protected bool $selfFiltering = false;
+
+    /**
      * AbstractFilter constructor.
      * @param string $fieldName
      * @param mixed $value
@@ -86,4 +92,25 @@ abstract class AbstractFilter implements FilterInterface
      * @inheritDoc
      */
     abstract public function filterInput(array $facetedData,  array &$inputIdKeys, array $excludeRecords): void;
+
+    /**
+     * Enable/Disable self-filtering for current filter, disabled by default.
+     * Used in AggregationQuery
+     * @param bool $enabled
+     * @return self 
+     */
+    public function selfFiltering(bool $enabled): self
+    {
+        $this->selfFiltering = $enabled;
+        return $this;
+    }
+
+    /**
+     * Get self-filtering flag
+     * @return boolean
+     */
+    public function getSelfFiltering(): bool
+    {
+        return $this->selfFiltering;
+    }
 }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -46,4 +46,11 @@ interface FilterInterface
      * @return void
      */
     public function filterInput(array $facetedData,  array &$inputIdKeys, array $excludeRecords): void;
+
+    /**
+     *  Get self-filtering flag
+     *
+     * @return bool
+     */
+    public function getSelfFiltering(): bool;
 }

--- a/src/Filter/FilterInterface.php
+++ b/src/Filter/FilterInterface.php
@@ -52,5 +52,5 @@ interface FilterInterface
      *
      * @return bool
      */
-    public function getSelfFiltering(): bool;
+    public function hasSelfFiltering(): bool;
 }

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -205,7 +205,7 @@ class Index implements IndexInterface
             $countValues,
             $input,
             $excludeMap,
-            $query->getSelfFiltering(),
+            $query->hasSelfFiltering(),
             $filters
         );
 
@@ -247,7 +247,7 @@ class Index implements IndexInterface
         foreach ($this->scanner->scan($this->storage) as $filterName => $filterValues) {
 
             $needSelfFiltering = false;
-            if ($selfFiltering != false || (isset($indexedFilters[$filterName]) && $indexedFilters[$filterName]->getSelfFiltering())) {
+            if ($selfFiltering != false || (isset($indexedFilters[$filterName]) && $indexedFilters[$filterName]->hasSelfFiltering())) {
                 $needSelfFiltering = true;
             }
 

--- a/src/Index/Index.php
+++ b/src/Index/Index.php
@@ -235,10 +235,22 @@ class Index implements IndexInterface
     ): array {
         $result = [];
         $cacheCount = count($resultCache);
+
+        $indexedFilters = [];
+        foreach ($filters as $filter) {
+            $indexedFilters[$filter->getFieldName()] = $filter;
+        }
+
         /**
          * @var array<int|string,array<int>> $filterValues
          */
         foreach ($this->scanner->scan($this->storage) as $filterName => $filterValues) {
+
+            $needSelfFiltering = false;
+            if ($selfFiltering != false || (isset($indexedFilters[$filterName]) && $indexedFilters[$filterName]->getSelfFiltering())) {
+                $needSelfFiltering = true;
+            }
+
             /**
              * @var string $filterName
              */
@@ -247,15 +259,16 @@ class Index implements IndexInterface
                 if ($cacheCount > 1) {
                     // optimization with cache of findRecordsMap
                     // do not apply self filtering
-                    if ($selfFiltering == false) {
-                        $skipKey = $filterName;
-                    } else {
+                    if ($needSelfFiltering) {
                         $skipKey = null;
+                    } else {
+                        $skipKey = $filterName;
                     }
+
                     $recordIds = $this->mergeFilters($resultCache, $skipKey);
                 } else {
                     // Selecting a self-filtering scenario 
-                    if ($selfFiltering) {
+                    if ($needSelfFiltering) {
                         $recordIds = $this->scanner->findRecordsMap($this->storage, $filters, $input, $exclude);
                     } else {
                         $recordIds = $this->scanner->findRecordsMap($this->storage, [], $input, $exclude);

--- a/src/Query/AggregationQuery.php
+++ b/src/Query/AggregationQuery.php
@@ -156,9 +156,9 @@ class AggregationQuery
 
     /**
      * Get self-filtering flag
-     * @return boolean
+     * @return bool
      */
-    public function getSelfFiltering(): bool
+    public function hasSelfFiltering(): bool
     {
         return $this->selfFiltering;
     }

--- a/src/Query/AggregationQuery.php
+++ b/src/Query/AggregationQuery.php
@@ -154,6 +154,10 @@ class AggregationQuery
         return $this;
     }
 
+    /**
+     * Get self-filtering flag
+     * @return boolean
+     */
     public function getSelfFiltering(): bool
     {
         return $this->selfFiltering;

--- a/tests/unit/Filter/SelfFilterTest.php
+++ b/tests/unit/Filter/SelfFilterTest.php
@@ -1,0 +1,121 @@
+<?php
+
+use PHPUnit\Framework\TestCase;
+use KSamuel\FacetedSearch\Filter\ValueFilter;
+use KSamuel\FacetedSearch\Filter\ValueIntersectionFilter;
+use KSamuel\FacetedSearch\Index\Factory;
+use KSamuel\FacetedSearch\Index\IndexInterface;
+use KSamuel\FacetedSearch\Query\AggregationQuery;
+
+class SelfFilterTest extends TestCase
+{
+    private function getIndex($type): IndexInterface
+    {
+        $index = (new Factory)->create(Factory::ARRAY_STORAGE);
+        $storage = $index->getStorage();
+        $data = [
+            1 => [
+                'brand' => 'Nony',
+                'first_usage' => ['weddings', 'wildlife'],
+                'second_usage' =>  ['wildlife', 'portraits']
+            ],
+            2 => [
+                'brand' => 'Mikon',
+                'first_usage' => ['weddings', 'streetphoto'],
+                'second_usage' =>  ['wildlife', 'streetphoto']
+            ],
+            3 => [
+                'brand' => 'Common',
+                'first_usage' => ['streetphoto', 'portraits'],
+                'second_usage' =>  ['streetphoto', 'portraits']
+            ],
+            4 => [
+                'brand' => 'Digma',
+                'first_usage' => ['streetphoto', 'portraits', 'weddings'],
+                'second_usage' =>  ['streetphoto', 'portraits']
+            ],
+            5 => [
+                'brand' => 'Digma',
+                'first_usage' => ['streetphoto'],
+                'second_usage' =>  ['portraits']
+            ],
+            6 => [
+                'brand' => 'Mikon',
+                'first_usage' => ['weddings', 'wildlife'],
+                'second_usage' =>  ['wildlife', 'portraits']
+            ]
+        ];
+        foreach ($data as $k => $v) {
+            $storage->addRecord($k, $v);
+        }
+        $storage->optimize();
+        return $index;
+    }
+    public function testMixedFiltering(): void
+    {
+        $query1 = (new AggregationQuery())->filters([
+            new ValueFilter('brand', ['Nony', 'Digma', 'Mikon']),
+            (new ValueIntersectionFilter('first_usage', ['weddings']))->selfFiltering(true),
+        ])->countItems()->sort();
+
+        $query2 = (new AggregationQuery())->filters([
+            new ValueFilter('brand', ['Nony', 'Digma']),
+            (new ValueIntersectionFilter('first_usage', ['weddings']))->selfFiltering(true),
+        ])->countItems()->sort();
+
+        $expect = [
+            'brand' => [
+                'Digma' => 1,
+                'Mikon' => 2,
+                'Nony' => 1
+            ],
+            'first_usage' => [
+                'portraits' => 1,
+                'streetphoto' => 2,
+                'weddings' => 4,
+                'wildlife' => 2
+            ],
+            'second_usage' => [
+                'portraits' => 3,
+                'streetphoto' => 2,
+                'wildlife' => 3,
+            ],
+        ];
+
+        $expect2 = [
+            'brand' => [
+                'Digma' => 1,
+                'Nony' => 1,
+                'Mikon' => 2,
+            ],
+            'first_usage' => [
+                'portraits' => 1,
+                'streetphoto' => 1,
+                'weddings' => 2,
+                'wildlife' => 1
+            ],
+            'second_usage' => [
+                'portraits' => 2,
+                'streetphoto' => 1,
+                'wildlife' => 1,
+            ],
+        ];
+
+        $index = $this->getIndex(Factory::ARRAY_STORAGE);
+        $result = $index->aggregate($query1);
+
+        $this->assertEquals($expect, $result);
+
+        $result = $index->aggregate($query2);
+        $this->assertEquals($expect2, $result);
+
+
+        $index = $this->getIndex(Factory::FIXED_ARRAY_STORAGE);
+        $result = $index->aggregate($query1);
+
+        $this->assertEquals($expect, $result);
+
+        $result = $index->aggregate($query2);
+        $this->assertEquals($expect2, $result);
+    }
+}

--- a/tests/unit/Filter/ValueIntersectionFilterTest.php
+++ b/tests/unit/Filter/ValueIntersectionFilterTest.php
@@ -124,7 +124,6 @@ class ValueIntersectionFilterTest extends TestCase
             new ValueIntersectionFilter('first_usage', ['wildlife', 'weddings', 'portraits']),
         ])->countItems()->sort()->selfFiltering(true);
 
-
         $index = $this->getIndex(Factory::ARRAY_STORAGE);
         $result = $index->aggregate($query1);
         $this->assertEquals([
@@ -220,5 +219,40 @@ class ValueIntersectionFilterTest extends TestCase
 
         $result = $index->aggregate($query4);
         $this->assertEquals([], $result);
+    }
+
+    public function testSelfFiltering(): void
+    {
+        $query1 = (new AggregationQuery())->filters([
+            new ValueIntersectionFilter('first_usage', ['streetphoto', 'portraits', 'weddings']),
+        ])->countItems()->sort()->selfFiltering(true);
+
+        $query2 = (new AggregationQuery())->filters([
+            (new ValueIntersectionFilter('first_usage', ['streetphoto', 'portraits', 'weddings']))->selfFiltering(true)
+        ])->countItems()->sort();
+
+
+        $index = $this->getIndex(Factory::ARRAY_STORAGE);
+        $result = $index->aggregate($query1);
+        $result2 = $index->aggregate($query2);
+
+        $expected = [
+            'brand' => [
+                'Digma' => 1,
+            ],
+            'first_usage' => [
+                'portraits' => 1,
+                'streetphoto' => 1,
+                'weddings' => 1,
+
+            ],
+            'second_usage' => [
+                'streetphoto' => 1,
+                'portraits' => 1,
+            ],
+        ];
+
+        $this->assertEquals($expected, $result);
+        $this->assertEquals($expected, $result2);
     }
 }


### PR DESCRIPTION
## Self-filtering option for individual filter (disabled by default). 
[Feature Request](https://github.com/k-samuel/faceted-search/issues/37)
Advanced configuration for AggregationQuery, if enabled, then result for filter can contain only filter values.
Useful for cases with ValueIntersectionFilter  (AND condition).
```php
$filters[] = (new ValueIntersectionFilter('size', [12,32]))->selfFiltering(true);
```
